### PR TITLE
Fix typo in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ $ yarn add is-online-component
 
 ```jsx
 import React from 'react';
-import IsOnline from 'is-online-component ';
+import IsOnline from 'is-online-component';
 
 const handleChange = (isOnline) => {
   console.log(isOnline);


### PR DESCRIPTION
This type will crash the application if you copy-paste it. It's not hard to find, it's just annoying when your app crashes. Therefore, this PR (I think the size of the "issue" is not worth a formal issue, hence just this PR).